### PR TITLE
Added serialization settings of File object; FileHelper class created

### DIFF
--- a/src/main/java/tech/becoming/fileservice/controller/FileController.java
+++ b/src/main/java/tech/becoming/fileservice/controller/FileController.java
@@ -1,5 +1,6 @@
 package tech.becoming.fileservice.controller;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
@@ -8,6 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import tech.becoming.fileservice.entity.File;
+import tech.becoming.fileservice.helper.FileHelper;
 import tech.becoming.fileservice.repository.FileRepository;
 import tech.becoming.fileservice.service.FileService;
 
@@ -18,6 +20,9 @@ import java.io.IOException;
 public class FileController {
 
     private final FileService fileService;
+
+    @Autowired
+    private FileHelper fileHelper;
 
     public FileController(FileService fileService) {
         this.fileService = fileService;
@@ -50,15 +55,9 @@ public class FileController {
     public ResponseEntity<Resource> downloadFile(@PathVariable String id) {
         final File file = fileService.findById(id);
 
-        return createDownloadResponse(file);
+        return fileHelper.createDownloadResponse(file);
     }
 
-    private ResponseEntity<Resource> createDownloadResponse(File file) {
-        return ResponseEntity
-                .ok()
-                .contentType(MediaType.APPLICATION_OCTET_STREAM)
-                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + file.getFileName() + "\"")
-                .body(new ByteArrayResource(file.getData()));
-    }
+
 
 }

--- a/src/main/java/tech/becoming/fileservice/entity/File.java
+++ b/src/main/java/tech/becoming/fileservice/entity/File.java
@@ -1,5 +1,6 @@
 package tech.becoming.fileservice.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.hibernate.annotations.GenericGenerator;
 
 import javax.persistence.Entity;
@@ -20,6 +21,7 @@ public class File {
     private String fileName;
 
     @Lob
+    @JsonIgnore
     private byte[] data;
 
     public String getId() {

--- a/src/main/java/tech/becoming/fileservice/helper/FileHelper.java
+++ b/src/main/java/tech/becoming/fileservice/helper/FileHelper.java
@@ -1,0 +1,20 @@
+package tech.becoming.fileservice.helper;
+
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import tech.becoming.fileservice.entity.File;
+
+@Component
+public class FileHelper {
+    public ResponseEntity<Resource> createDownloadResponse(File file) {
+        return ResponseEntity
+                .ok()
+                .contentType(MediaType.APPLICATION_OCTET_STREAM)
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + file.getFileName() + "\"")
+                .body(new ByteArrayResource(file.getData()));
+    }
+}

--- a/src/main/java/tech/becoming/fileservice/service/FileService.java
+++ b/src/main/java/tech/becoming/fileservice/service/FileService.java
@@ -28,8 +28,6 @@ public class FileService {
                 .findById(id)
                 .orElseThrow(NotFoundException::new);
 
-        file.setData(null);
-
         return file;
     }
 


### PR DESCRIPTION
I think will be better to annotate "data" field in File class with JsonIgnore to prevent it from serialization than setting it every time to null manually.

Due to SOLID principles, FileController has single responsibility for routing api calls, therefore I think it's better to move createDownloadResponce method to FileHelper class. 